### PR TITLE
Rollback styles support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ These might give you results you didn't want:
 
 #### Styling your copy
 
-There a few things you need to keep in mind with this plugin.
+<!-- There a few things you need to keep in mind with this plugin. -->
 
-First: You're replacing entire contents of a text node, **including styles**. {{copyThat.airtable}} applies the first character's style to the entire node. In most cases, this will probably be regular text. But if you want an entire node to be italicized? Just italicize (at least) the first character, and the entire node will adopt that style.
+<!-- First: -->
+You're replacing entire contents of a text node, **including styles**. {{copyThat.airtable}} applies the first character's style to the entire node. In most cases, this will probably be regular text. But if you want an entire node to be italicized? Just italicize (at least) the first character, and the entire node will adopt that style.
 
-Second: The plugin supports bold, italic, and bold-italic formatting with HTML tags. So if you surround text with `<b></b>`, `<i></i>`, or `<b><i></i></b>` tags, they'll render appropriately. I plan to add markdown support in the future.
+<!-- Second: The plugin supports bold, italic, and bold-italic formatting with HTML tags. So if you surround text with `<b></b>`, `<i></i>`, or `<b><i></i></b>` tags, they'll render appropriately. I plan to add markdown support in the future. -->
 
 ### 3. Sync
 

--- a/src/replace-text.ts
+++ b/src/replace-text.ts
@@ -67,7 +67,10 @@ const replaceTheText = async (node: TextNode, airtableData: object) => {
   node.setRangeFontName(0, node.characters.length, firstCharFontName)
 
   // Replace the node and apply formatting
-  str = formatNode(node, str, fontFamily)
+  // formatNode(node, str, fontFamily) // TODO debug this
+
+  // Replace the node
+  node.characters = str
 }
 
 /**
@@ -121,4 +124,3 @@ const getPage = (node) => {
   while (node && node.type !== 'PAGE') { node = node.parent; }
   return node;
 }
-


### PR DESCRIPTION
The last release introduced a critical bug where the plugin wouldn't run at all. I traced this back to my support for styles and disabled it. Everything's working normally, and I'll have to revisit the styles implementation and do better.

I'll have to release this immediately because this is a breaking change for every action in the plugin.

When I run the plugin in development mode, the bug went uncaught. It didn't show itself until I built. This is the strongest case for building out automated testing. 